### PR TITLE
Add procCallback to spawn and exec functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,8 @@ typings/
 # next.js build output
 .next
 
+# Webstorm project directory
+/.idea
+
+# Build output directory
 dist/

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,4 +1,4 @@
-import {ExecOptions, exec as nodeExec} from 'child_process';
+import {ChildProcess, ExecOptions, exec as nodeExec} from 'child_process';
 
 import {Observable, Subscriber} from 'rxjs';
 
@@ -7,7 +7,8 @@ import {ShellError, killProc, listenTerminating} from './util';
 
 export function exec(
   command: string,
-  options?: ExecOptions
+  options?: ExecOptions,
+  procCallback?: (proc: ChildProcess) => void
 ): Observable<ExecOutput> {
   return new Observable((subscriber: Subscriber<ExecOutput>) => {
     const proc = nodeExec(command, options, (err, stdout, stderr) => {
@@ -24,6 +25,10 @@ export function exec(
     });
 
     const removeEvents = listenTerminating(() => subscriber.complete());
+
+    if (procCallback) {
+      procCallback(proc);
+    }
 
     return () => {
       killProc(proc);

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -1,6 +1,9 @@
-import {Observable} from 'rxjs';
+import {ExecOptions} from 'child_process';
 
-import {isExecOutput, isSpawnChunk} from './models';
+import {Observable, mergeMap} from 'rxjs';
+
+import {exec} from './exec';
+import {ExecOutput, isExecOutput, isSpawnChunk} from './models';
 import {ShellError} from './util';
 
 export function trim<T>(encoding: BufferEncoding = 'utf8') {
@@ -180,5 +183,20 @@ export function throwIfStderr<T>(pattern: string | RegExp) {
 
       return subscription;
     });
+  };
+}
+
+export function execWithStdin(command: string, options?: ExecOptions) {
+  return function execWithStdinImplementation(
+    source: Observable<string>
+  ): Observable<ExecOutput> {
+    return source.pipe(
+      mergeMap(input =>
+        exec(command, options, proc => {
+          proc.stdin?.write(input);
+          proc.stdin?.end();
+        })
+      )
+    );
   };
 }

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -1,11 +1,20 @@
-import {SpawnOptions, spawn as nodeSpawn} from 'child_process';
+import {
+  ChildProcessWithoutNullStreams,
+  SpawnOptions,
+  spawn as nodeSpawn,
+} from 'child_process';
 
 import {Observable, Subscriber} from 'rxjs';
 
 import {SpawnChunk} from './models';
 import {ShellError, killProc, listenTerminating} from './util';
 
-export function spawn(command: string, args?: any[], options?: SpawnOptions) {
+export function spawn(
+  command: string,
+  args?: any[],
+  options?: SpawnOptions,
+  procCallback?: (proc: ChildProcessWithoutNullStreams) => void
+) {
   return new Observable((subscriber: Subscriber<SpawnChunk>) => {
     const proc = nodeSpawn(
       command,
@@ -62,6 +71,10 @@ export function spawn(command: string, args?: any[], options?: SpawnOptions) {
     });
 
     const removeEvents = listenTerminating(() => subscriber.complete());
+
+    if (procCallback) {
+      procCallback(proc);
+    }
 
     return () => {
       killProc(proc);

--- a/test/exec.spec.ts
+++ b/test/exec.spec.ts
@@ -13,6 +13,16 @@ describe('exec.ts', () => {
     });
   });
 
+  it('should call procCallback with ChildProcess object', done => {
+    exec('cat -', undefined, proc => {
+      proc.stdin?.write('Hello World');
+      proc.stdin?.end();
+    }).subscribe(output => {
+      expect(String(output.stdout).trim()).to.equal('Hello World');
+      done();
+    });
+  });
+
   it('should return stderr text.', done => {
     exec('>&2 echo "ERR"').subscribe(output => {
       expect(String(output.stderr).trim()).to.equal('ERR');

--- a/test/operators.spec.ts
+++ b/test/operators.spec.ts
@@ -1,8 +1,16 @@
 import * as chai from 'chai';
+import {expect} from 'chai';
 import chaiExclude from 'chai-exclude';
+import {of, tap} from 'rxjs';
 import {TestScheduler} from 'rxjs/testing';
 
-import {throwIf, throwIfStderr, throwIfStdout, trim} from '../src/operators';
+import {
+  execWithStdin,
+  throwIf,
+  throwIfStderr,
+  throwIfStdout,
+  trim,
+} from '../src/operators';
 import {ShellError} from '../src/util';
 
 chai.use(chaiExclude);
@@ -295,6 +303,17 @@ describe('operators.ts', () => {
           x: value,
         });
       });
+    });
+  });
+
+  describe('execWithStdin', () => {
+    it('should exec with string input', done => {
+      of('Hello World')
+        .pipe(execWithStdin('cat -'))
+        .subscribe(output => {
+          expect(String(output.stdout).trim()).to.equal('Hello World');
+          done();
+        });
     });
   });
 });

--- a/test/spawn.spec.ts
+++ b/test/spawn.spec.ts
@@ -14,6 +14,16 @@ describe('spawn.ts', () => {
     });
   });
 
+  it('should should call procCallback', done => {
+    spawn('cat', ['-'], undefined, proc => {
+      proc.stdin.write('hello world');
+      proc.stdin.end();
+    }).subscribe(output => {
+      expect(String(output.chunk).trim()).to.equal('hello world');
+      done();
+    });
+  });
+
   it('should return stderr text.', done => {
     spawn('sh', [join(process.cwd(), 'test/fixtures/echoStderr.sh')]).subscribe(
       output => {


### PR DESCRIPTION
This PR adds a callback with the process object to the spawn function.

Use case: I want to access the stdin of the child process somehow. This is possible via the callback.